### PR TITLE
[Refactor] Improved Sub Engine ResponseHelper

### DIFF
--- a/src/main/java/io/uranus/utility/bundle/core/global/support/test/dummy/DummyObjectResponseCopied.java
+++ b/src/main/java/io/uranus/utility/bundle/core/global/support/test/dummy/DummyObjectResponseCopied.java
@@ -1,5 +1,6 @@
 package io.uranus.utility.bundle.core.global.support.test.dummy;
 
+import io.uranus.utility.bundle.core.utility.response.helper.annotation.MappedField;
 import lombok.*;
 
 @Getter
@@ -10,4 +11,6 @@ public class DummyObjectResponseCopied {
 
     private String someValue;
     private String someValue2;
+    @MappedField(origin = "someValue3")
+    private String otherNameField;
 }

--- a/src/main/java/io/uranus/utility/bundle/core/utility/response/helper/annotation/MappedField.java
+++ b/src/main/java/io/uranus/utility/bundle/core/utility/response/helper/annotation/MappedField.java
@@ -1,0 +1,13 @@
+package io.uranus.utility.bundle.core.utility.response.helper.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface MappedField {
+
+    String origin();
+}

--- a/src/main/java/io/uranus/utility/bundle/core/utility/response/helper/transformer/ResponseTransformer.java
+++ b/src/main/java/io/uranus/utility/bundle/core/utility/response/helper/transformer/ResponseTransformer.java
@@ -1,5 +1,6 @@
 package io.uranus.utility.bundle.core.utility.response.helper.transformer;
 
+import io.uranus.utility.bundle.core.utility.response.helper.annotation.MappedField;
 import io.uranus.utility.bundle.core.utility.response.helper.storage.ResponseTransformCacheContainer;
 
 import java.lang.reflect.Constructor;
@@ -38,14 +39,32 @@ public class ResponseTransformer<T, R> {
 
             R returnClass = declaredConstructor.newInstance();
 
-            for (Map.Entry<String, Field> entry : originClassFields.entrySet()) {
-                String fieldName = entry.getKey();
-                Field originField = entry.getValue();
-                Field returnField = returnClassFields.get(fieldName);
+            for (Map.Entry<String, Field> entry : returnClassFields.entrySet()) {
+                String returnFieldName = entry.getKey();
+                Field returnField = entry.getValue();
 
-                if (returnField != null) {
-                    Object value = originField.get(originClass);
-                    returnField.set(returnClass, value);
+                if (returnField.isAnnotationPresent(MappedField.class)) {
+                    MappedField mappedField = returnField.getAnnotation(MappedField.class);
+
+                    Field originField = originClassFields.get(mappedField.origin());
+
+                    if (originField != null) {
+                        Object val = originField.get(this.originClass);
+
+                        if (val != null) {
+                            returnField.set(returnClass, val);
+                        }
+                    }
+                } else {
+                    Field originField = originClassFields.get(returnFieldName);
+
+                    if (originField != null) {
+                        Object val = originField.get(this.originClass);
+
+                        if (val != null) {
+                            returnField.set(returnClass, val);
+                        }
+                    }
                 }
             }
 

--- a/src/test/java/io/uranus/utility/bundle/core/utility/ResponseSubEngineTest.java
+++ b/src/test/java/io/uranus/utility/bundle/core/utility/ResponseSubEngineTest.java
@@ -21,6 +21,7 @@ public class ResponseSubEngineTest {
         Assertions.assertNotNull(transformedResponse);
         Assertions.assertEquals(origin.getSomeValue(), transformedResponse.getSomeValue());
         Assertions.assertEquals(origin.getSomeValue2(), transformedResponse.getSomeValue2());
+        Assertions.assertEquals(origin.getSomeValue3(), transformedResponse.getOtherNameField());
 
         Assertions.assertEquals(2, ResponseTransformCacheContainer.containedSize());
     }

--- a/src/test/java/io/uranus/utility/bundle/core/utility/UranusUtilityEngineTest.java
+++ b/src/test/java/io/uranus/utility/bundle/core/utility/UranusUtilityEngineTest.java
@@ -249,6 +249,7 @@ class UranusUtilityEngineTest {
         Assertions.assertNotNull(transformedResponse);
         Assertions.assertEquals(origin.getSomeValue(), transformedResponse.getSomeValue());
         Assertions.assertEquals(origin.getSomeValue2(), transformedResponse.getSomeValue2());
+        Assertions.assertEquals(origin.getSomeValue3(), transformedResponse.getOtherNameField());
 
         Assertions.assertEquals(2, ResponseTransformCacheContainer.containedSize());
     }


### PR DESCRIPTION
- The transformation process has been improved to support field name differences using the @MappedField annotation, allowing it to reflect the original class's field names.
- For example, if the field name in the response class is "otherNameField" and the field name in the original class is "someValue3", the value of "someValue3" will be copied if otherNameField is annotated with @MappedField(origin = "someValue3").