### PR TITLE
[Feature] Added ignore Option to ResponseTransform

### DIFF
--- a/src/main/java/io/uranus/utility/bundle/core/global/support/test/dummy/DummyObject.java
+++ b/src/main/java/io/uranus/utility/bundle/core/global/support/test/dummy/DummyObject.java
@@ -12,9 +12,10 @@ public class DummyObject {
     private String someValue;
     private String someValue2;
     private String someValue3;
+    private String ignoreField;
 
     public static DummyObject createObject() {
-        return new DummyObject("someValue", "someValue2", "someValue3");
+        return new DummyObject("someValue", "someValue2", "someValue3", "ignoreField");
     }
 
 }

--- a/src/main/java/io/uranus/utility/bundle/core/global/support/test/dummy/DummyObjectResponseCopied.java
+++ b/src/main/java/io/uranus/utility/bundle/core/global/support/test/dummy/DummyObjectResponseCopied.java
@@ -13,4 +13,6 @@ public class DummyObjectResponseCopied {
     private String someValue2;
     @MappedField(origin = "someValue3")
     private String otherNameField;
+    @MappedField(ignore = true)
+    private String ignoreField;
 }

--- a/src/main/java/io/uranus/utility/bundle/core/utility/response/helper/annotation/MappedField.java
+++ b/src/main/java/io/uranus/utility/bundle/core/utility/response/helper/annotation/MappedField.java
@@ -9,5 +9,6 @@ import java.lang.annotation.Target;
 @Target(ElementType.FIELD)
 public @interface MappedField {
 
-    String origin();
+    String origin() default "";
+    boolean ignore() default false;
 }

--- a/src/main/java/io/uranus/utility/bundle/core/utility/response/helper/transformer/ResponseTransformer.java
+++ b/src/main/java/io/uranus/utility/bundle/core/utility/response/helper/transformer/ResponseTransformer.java
@@ -17,7 +17,7 @@ public class ResponseTransformer<T, R> {
     }
 
     protected ResponseTransformer<T, R> createInstance(Class<R> returnClass) {
-        return new ResponseTransformer(returnClass);
+        return new ResponseTransformer<T, R>(returnClass);
     }
 
     public ResponseTransformer<T, R> withOrigin(T origin) {
@@ -45,6 +45,10 @@ public class ResponseTransformer<T, R> {
 
                 if (returnField.isAnnotationPresent(MappedField.class)) {
                     MappedField mappedField = returnField.getAnnotation(MappedField.class);
+
+                    if (mappedField.ignore()) {
+                        continue;
+                    }
 
                     Field originField = originClassFields.get(mappedField.origin());
 

--- a/src/test/java/io/uranus/utility/bundle/core/utility/ResponseSubEngineTest.java
+++ b/src/test/java/io/uranus/utility/bundle/core/utility/ResponseSubEngineTest.java
@@ -27,4 +27,16 @@ public class ResponseSubEngineTest {
 
         Assertions.assertEquals(2, ResponseTransformCacheContainer.containedSize());
     }
+
+    @Test
+    void responseTransformIgnore() {
+        DummyObject origin = DummyObject.createObject();
+
+        DummyObjectResponseCopied transformed = UranusUtilityEngine.response().transformerFor(DummyObjectResponseCopied.class)
+                .withOrigin(origin)
+                .transform();
+
+        Assertions.assertNotNull(transformed);
+        Assertions.assertNull(transformed.getIgnoreField());
+    }
 }


### PR DESCRIPTION
- The ignore option can now be used in the @MappedField annotation. It is applied as a boolean flag, and any target fields with this annotation will be ignored.
- Test cases for the ignore option have been added.