### PR TITLE
[Refactor] Changed Json ElementParser Node Navigation Method

### DIFF
--- a/src/main/java/io/uranus/utility/bundle/core/utility/json/helper/extractor/JsonElementExtractor.java
+++ b/src/main/java/io/uranus/utility/bundle/core/utility/json/helper/extractor/JsonElementExtractor.java
@@ -1,10 +1,13 @@
 package io.uranus.utility.bundle.core.utility.json.helper.extractor;
 
+import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.uranus.utility.bundle.core.utility.support.cache.JsonPointerCacheContainer;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class JsonElementExtractor {
 
@@ -48,20 +51,23 @@ public class JsonElementExtractor {
             throw new IllegalArgumentException("from and target cannot be empty or null.");
         }
 
+        String joinedPoint = String.join("/", targets);
+        String navigatePoint = "/" + joinedPoint;
+
+        JsonPointer jsonPointer = JsonPointerCacheContainer.computeJsonPointer(navigatePoint);
+
         try {
             JsonNode node = om.readTree(json);
 
-            for (String target : targets) {
-                node = node.path(target);
-                if (node.isMissingNode()) {
-                    throw new IllegalAccessException("Not exists field name" + target + " in json");
-                }
+            node = node.at(jsonPointer);
+
+            if (node.isMissingNode()) {
+                throw new IllegalAccessException("Not exists path [" + navigatePoint + "] in json");
             }
 
             return node.asText();
-        } catch (Exception suppressed) {
+        } catch (Exception e) {
+            throw new RuntimeException(e);
         }
-
-        return null;
     }
 }

--- a/src/main/java/io/uranus/utility/bundle/core/utility/support/cache/JsonPointerCacheContainer.java
+++ b/src/main/java/io/uranus/utility/bundle/core/utility/support/cache/JsonPointerCacheContainer.java
@@ -1,0 +1,36 @@
+package io.uranus.utility.bundle.core.utility.support.cache;
+
+import com.fasterxml.jackson.core.JsonPointer;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class JsonPointerCacheContainer {
+
+    private static final Map<String, JsonPointer> JSON_POINTER_CACHE_CONTAINER = new ConcurrentHashMap<>();
+    private static final Map<String, AtomicInteger> NAVIGATE_POINT_INVOCATION_COUNTER = new ConcurrentHashMap<>();
+    private static final int HOT_SPOT_THRESHOLD = 10;
+
+    public static JsonPointer computeJsonPointer(String navigatePoint) {
+        NAVIGATE_POINT_INVOCATION_COUNTER.computeIfAbsent(navigatePoint, key -> new AtomicInteger(0)).incrementAndGet();
+
+        if (isHotSpot(navigatePoint)) {
+            return JSON_POINTER_CACHE_CONTAINER.computeIfAbsent(navigatePoint, JsonPointer::compile);
+        }
+
+        return JsonPointer.compile(navigatePoint);
+    }
+
+    private static boolean isHotSpot(String navigatePoint) {
+        return NAVIGATE_POINT_INVOCATION_COUNTER.get(navigatePoint).get() >= HOT_SPOT_THRESHOLD;
+    }
+
+    public static Integer containedSize() {
+        return JSON_POINTER_CACHE_CONTAINER.size();
+    }
+
+    public static void clear() {
+        JSON_POINTER_CACHE_CONTAINER.clear();
+    }
+}

--- a/src/test/java/io/uranus/utility/bundle/core/utility/JsonSubEngineTest.java
+++ b/src/test/java/io/uranus/utility/bundle/core/utility/JsonSubEngineTest.java
@@ -124,6 +124,18 @@ public class JsonSubEngineTest {
         Assertions.assertThat(recovery.size()).isEqualTo(1000000);
     }
 
+    @Test
+    void navigateJson() {
+        String json = convertedDummyObject();
+
+        String val = UranusUtilityEngine.json().elementExtraction()
+                .withJson(json)
+                .navigate("someValue")
+                .extract();
+
+        Assertions.assertThat(val).isEqualTo("someValue");
+    }
+
     private String convertedDummyObject() {
         return UranusUtilityEngine.json().writeToJson(DummyObject.createObject());
     }


### PR DESCRIPTION
- The ElementParser has been modified to use JsonPointer when navigating JsonNode.
- JsonPointer is managed by JsonPointerCacheContainer and is cached when specific conditions are met.