### PR TITLE
[Feature] New Sub Engine NetworkHelper Created

### DIFF
--- a/src/main/java/io/uranus/utility/bundle/core/utility/UranusUtilityEngine.java
+++ b/src/main/java/io/uranus/utility/bundle/core/utility/UranusUtilityEngine.java
@@ -3,6 +3,7 @@ package io.uranus.utility.bundle.core.utility;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.uranus.utility.bundle.core.utility.chrono.helper.ChronoHelper;
+import io.uranus.utility.bundle.core.utility.connection.helper.NetworkHelper;
 import io.uranus.utility.bundle.core.utility.json.helper.JsonHelper;
 import io.uranus.utility.bundle.core.utility.redis.helper.RedisHelper;
 import io.uranus.utility.bundle.core.utility.response.helper.ResponseHelper;
@@ -11,6 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -22,10 +24,12 @@ public class UranusUtilityEngine {
 
     private static RedisTemplate<String, String> REDIS_TEMPLATE_INSTANCE;
     private static final ObjectMapper OBJECT_MAPPER_INSTANCE = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES, false);
+    private static final RestTemplate REST_TEMPLATE_INSTANCE = new RestTemplate();
     private static JsonHelper JSON_HELPER_INSTANCE;
     private static ChronoHelper CHRONO_HELPER_INSTANCE;
     private static RedisHelper REDIS_HELPER_INSTANCE;
     private static ResponseHelper RESPONSE_HELPER_INSTANCE;
+    private static NetworkHelper NETWORK_HELPER_INSTANCE;
 
     @Autowired
     public UranusUtilityEngine(@Qualifier("stringRedisTemplate") RedisTemplate<String, String> redisTemplate) {
@@ -38,6 +42,7 @@ public class UranusUtilityEngine {
         CHRONO_HELPER_INSTANCE = ChronoUtilityDelegate.getInstance();
         REDIS_HELPER_INSTANCE = RedisUtilityDelegate.getInstance();
         RESPONSE_HELPER_INSTANCE = ResponseUtilityDelegate.getInstance();
+        NETWORK_HELPER_INSTANCE = NetworkUtilityDelegate.getInstance();
     }
 
     /**
@@ -61,6 +66,10 @@ public class UranusUtilityEngine {
 
     public static ResponseHelper response() {
         return RESPONSE_HELPER_INSTANCE;
+    }
+
+    public static NetworkHelper network() {
+        return NETWORK_HELPER_INSTANCE;
     }
 
     /**
@@ -406,6 +415,16 @@ public class UranusUtilityEngine {
 
         protected static ResponseHelper getInstance() {
             return ResponseHelper.createInstance();
+        }
+    }
+
+    private static class NetworkUtilityDelegate extends NetworkHelper {
+        private NetworkUtilityDelegate() {
+            super(REST_TEMPLATE_INSTANCE);
+        }
+
+        protected static NetworkHelper getInstance() {
+            return NetworkHelper.getInstance(REST_TEMPLATE_INSTANCE);
         }
     }
 }

--- a/src/main/java/io/uranus/utility/bundle/core/utility/connection/helper/NetworkHelper.java
+++ b/src/main/java/io/uranus/utility/bundle/core/utility/connection/helper/NetworkHelper.java
@@ -1,0 +1,32 @@
+package io.uranus.utility.bundle.core.utility.connection.helper;
+
+import io.uranus.utility.bundle.core.utility.connection.helper.connector.NetworkConnector;
+import io.uranus.utility.bundle.core.utility.connection.helper.connector.element.phase.HttpMethodPhase;
+import org.springframework.web.client.RestTemplate;
+
+public class NetworkHelper {
+
+    protected final RestTemplate restTemplate;
+
+    protected NetworkHelper(RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+    }
+
+    protected static NetworkHelper getInstance(RestTemplate restTemplate) {
+        return new NetworkHelper(restTemplate);
+    }
+
+    public HttpMethodPhase open() {
+        return NetworkConnectorDelegate.getInstance(restTemplate);
+    }
+
+    private static class NetworkConnectorDelegate extends NetworkConnector {
+        private NetworkConnectorDelegate(RestTemplate restTemplate) {
+            super(restTemplate);
+        }
+
+        protected static NetworkConnector getInstance(RestTemplate restTemplate) {
+            return new NetworkConnectorDelegate(restTemplate);
+        }
+    }
+}

--- a/src/main/java/io/uranus/utility/bundle/core/utility/connection/helper/connector/NetworkConnector.java
+++ b/src/main/java/io/uranus/utility/bundle/core/utility/connection/helper/connector/NetworkConnector.java
@@ -1,0 +1,255 @@
+package io.uranus.utility.bundle.core.utility.connection.helper.connector;
+
+import io.uranus.utility.bundle.core.utility.connection.helper.connector.element.phase.*;
+import io.uranus.utility.bundle.core.utility.connection.helper.connector.element.result.ExternalNetworkResponse;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.*;
+import java.util.function.Consumer;
+
+public class NetworkConnector implements HttpMethodPhase,
+        UrlBindPhase,
+        HttpHeaderBindPhase,
+        HttpBodyMountPhase,
+        FinalExecutionPhase {
+
+    private final RestTemplate restTemplate;
+    private final ConnectionPipeline<NetworkConnector> pipeline = new ConnectionPipeline<>();
+
+    private boolean useHttps = false;
+    private String URL;
+    private HttpMethod httpMethod;
+    private final MultiValueMap<String, String> headers = new LinkedMultiValueMap<>();
+    private final MultiValueMap<String, Object> form = new LinkedMultiValueMap<>();
+    private final Map<String, String> queryParams = new LinkedHashMap<>();
+    private String body;
+
+
+    protected NetworkConnector(RestTemplate restTemplate) {
+        if (restTemplate == null) {
+            throw new IllegalArgumentException("restTemplate cannot be null");
+        }
+
+        this.restTemplate = restTemplate;
+    }
+
+    protected static NetworkConnector createInstance(RestTemplate restTemplate) {
+        return new NetworkConnector(restTemplate);
+    }
+
+    @Override
+    public HttpMethodPhase https() {
+        pipeline.add(c -> c.useHttps = true);
+
+        return this;
+    }
+
+    @Override
+    public UrlBindPhase get() {
+        pipeline.add(c -> c.httpMethod = HttpMethod.GET);
+
+        return this;
+    }
+
+    @Override
+    public UrlBindPhase post() {
+        pipeline.add(c -> c.httpMethod = HttpMethod.POST);
+
+        return this;
+    }
+
+    @Override
+    public UrlBindPhase patch() {
+        pipeline.add(c -> c.httpMethod = HttpMethod.PATCH);
+
+        return this;
+    }
+
+    @Override
+    public UrlBindPhase put() {
+        pipeline.add(c -> c.httpMethod = HttpMethod.PUT);
+
+        return this;
+    }
+
+    @Override
+    public UrlBindPhase delete() {
+        pipeline.add(c -> c.httpMethod = HttpMethod.DELETE);
+
+        return this;
+    }
+
+    @Override
+    public UrlBindPhase options() {
+        pipeline.add(c -> c.httpMethod = HttpMethod.OPTIONS);
+
+        return this;
+    }
+
+    @Override
+    public HttpHeaderBindPhase url(String url) {
+        pipeline.add(c -> c.URL = url);
+
+        return this;
+    }
+
+    @Override
+    public HttpBodyMountPhase headers(Consumer<MultiValueMap<String, String>> consumer) {
+        pipeline.add(c -> consumer.accept(c.headers));
+
+        return this;
+    }
+
+    @Override
+    public FinalExecutionPhase body(String body) {
+        pipeline.add(c -> c.body = body);
+
+        return this;
+    }
+
+    @Override
+    public FinalExecutionPhase queryParams(Consumer<Map<String, String>> consumer) {
+        pipeline.add(c -> consumer.accept(c.queryParams));
+
+        return this;
+    }
+
+    @Override
+    public FinalExecutionPhase form(Consumer<MultiValueMap<String, Object>> consumer) {
+        pipeline.add(c -> consumer.accept(c.form));
+
+        return this;
+    }
+
+    @Override
+    public ExternalNetworkResponse execute() {
+        pipeline.execute(this);
+
+        if (this.useHttps && !this.URL.startsWith("https")) {
+            this.URL = this.URL.replace("http", "https");
+        }
+
+        if (this.httpMethod == HttpMethod.GET) {
+            if (!this.queryParams.isEmpty()) {
+                if (this.URL.endsWith("/")) {
+                    this.URL = this.URL.substring(0, this.URL.length() - 1);
+                }
+
+                if (!this.URL.endsWith("?")) {
+                    this.URL = this.URL + "?";
+                }
+
+                StringJoiner joiner = new StringJoiner("&");
+
+                for (Map.Entry<String, String> entry : this.queryParams.entrySet()) {
+                    joiner.add(entry.getKey() + "=" + entry.getValue());
+                }
+
+                this.URL = this.URL + joiner;
+            }
+
+            return queryParamConnection();
+        }
+
+        if (this.httpMethod == HttpMethod.POST) {
+            if (this.form.isEmpty() && this.body != null) {
+                return bodyConnection();
+            }
+
+            if (!this.form.isEmpty() && this.body == null) {
+                return formConnection();
+            }
+        }
+
+        if (this.httpMethod == HttpMethod.PATCH || this.httpMethod == HttpMethod.PUT || this.httpMethod == HttpMethod.DELETE) {
+            return bodyConnection();
+        }
+
+        throw new RuntimeException("Can't handle http connection.");
+    }
+
+    private ExternalNetworkResponse queryParamConnection() {
+        HttpEntity<Object> httpEntity = new HttpEntity<>(this.headers);
+
+        try {
+            ResponseEntity<String> exchange = restTemplate.exchange(this.URL,
+                    this.httpMethod,
+                    httpEntity,
+                    String.class);
+
+            return ExternalNetworkResponse.create(exchange.getStatusCode(), exchange.getBody());
+        } catch (RestClientException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private ExternalNetworkResponse bodyConnection() {
+        if (this.body != null && !this.body.isEmpty() && !this.body.isBlank()) {
+            HttpEntity<String> httpEntity = new HttpEntity<>(this.body, this.headers);
+
+            try {
+                ResponseEntity<String> exchange = restTemplate.exchange(this.URL,
+                        this.httpMethod,
+                        httpEntity,
+                        String.class);
+
+                return ExternalNetworkResponse.create(exchange.getStatusCode(), exchange.getBody());
+            } catch (RestClientException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        HttpEntity<String> httpEntity = new HttpEntity<>(this.headers);
+
+        try {
+            ResponseEntity<String> exchange = restTemplate.exchange(this.URL,
+                    this.httpMethod,
+                    httpEntity,
+                    String.class);
+
+            return ExternalNetworkResponse.create(exchange.getStatusCode(), exchange.getBody());
+        } catch (RestClientException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private ExternalNetworkResponse formConnection() {
+        HttpEntity<MultiValueMap<String, Object>> httpEntity = new HttpEntity<>(this.form, this.headers);
+
+        try {
+            ResponseEntity<String> exchange = restTemplate.exchange(this.URL,
+                    this.httpMethod,
+                    httpEntity,
+                    String.class);
+
+            return ExternalNetworkResponse.create(exchange.getStatusCode(), exchange.getBody());
+        } catch (RestClientException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    protected static class ConnectionPipeline<T> {
+        private final List<PipelineElement<T>> pipeline = new LinkedList<>();
+
+        public void add(PipelineElement<T> element) {
+            this.pipeline.add(element);
+        }
+
+        public void execute(T input) {
+            for (PipelineElement<T> item : pipeline) {
+                item.apply(input);
+            }
+        }
+    }
+
+    @FunctionalInterface
+    protected interface PipelineElement<T> {
+        void apply(T element);
+    }
+}

--- a/src/main/java/io/uranus/utility/bundle/core/utility/connection/helper/connector/element/phase/FinalExecutionPhase.java
+++ b/src/main/java/io/uranus/utility/bundle/core/utility/connection/helper/connector/element/phase/FinalExecutionPhase.java
@@ -1,0 +1,8 @@
+package io.uranus.utility.bundle.core.utility.connection.helper.connector.element.phase;
+
+import io.uranus.utility.bundle.core.utility.connection.helper.connector.element.result.ExternalNetworkResponse;
+
+public interface FinalExecutionPhase {
+
+    ExternalNetworkResponse execute();
+}

--- a/src/main/java/io/uranus/utility/bundle/core/utility/connection/helper/connector/element/phase/HttpBodyMountPhase.java
+++ b/src/main/java/io/uranus/utility/bundle/core/utility/connection/helper/connector/element/phase/HttpBodyMountPhase.java
@@ -1,0 +1,16 @@
+package io.uranus.utility.bundle.core.utility.connection.helper.connector.element.phase;
+
+import io.uranus.utility.bundle.core.utility.connection.helper.connector.NetworkConnector;
+import org.springframework.util.MultiValueMap;
+
+import java.util.Map;
+import java.util.function.Consumer;
+
+public interface HttpBodyMountPhase {
+
+    FinalExecutionPhase body(String body);
+
+    FinalExecutionPhase queryParams(Consumer<Map<String, String>> consumer);
+
+    FinalExecutionPhase form(Consumer<MultiValueMap<String, Object>> consumer);
+}

--- a/src/main/java/io/uranus/utility/bundle/core/utility/connection/helper/connector/element/phase/HttpHeaderBindPhase.java
+++ b/src/main/java/io/uranus/utility/bundle/core/utility/connection/helper/connector/element/phase/HttpHeaderBindPhase.java
@@ -1,0 +1,10 @@
+package io.uranus.utility.bundle.core.utility.connection.helper.connector.element.phase;
+
+import org.springframework.util.MultiValueMap;
+
+import java.util.function.Consumer;
+
+public interface HttpHeaderBindPhase {
+
+    HttpBodyMountPhase headers(Consumer<MultiValueMap<String, String>> consumer);
+}

--- a/src/main/java/io/uranus/utility/bundle/core/utility/connection/helper/connector/element/phase/HttpMethodPhase.java
+++ b/src/main/java/io/uranus/utility/bundle/core/utility/connection/helper/connector/element/phase/HttpMethodPhase.java
@@ -1,0 +1,19 @@
+package io.uranus.utility.bundle.core.utility.connection.helper.connector.element.phase;
+
+public interface HttpMethodPhase {
+
+    HttpMethodPhase https();
+
+    UrlBindPhase get();
+
+    UrlBindPhase post();
+
+    UrlBindPhase patch();
+
+    UrlBindPhase put();
+
+    UrlBindPhase delete();
+
+    UrlBindPhase options();
+
+}

--- a/src/main/java/io/uranus/utility/bundle/core/utility/connection/helper/connector/element/phase/UrlBindPhase.java
+++ b/src/main/java/io/uranus/utility/bundle/core/utility/connection/helper/connector/element/phase/UrlBindPhase.java
@@ -1,0 +1,6 @@
+package io.uranus.utility.bundle.core.utility.connection.helper.connector.element.phase;
+
+public interface UrlBindPhase {
+
+    HttpHeaderBindPhase url(String url);
+}

--- a/src/main/java/io/uranus/utility/bundle/core/utility/connection/helper/connector/element/result/ExternalNetworkResponse.java
+++ b/src/main/java/io/uranus/utility/bundle/core/utility/connection/helper/connector/element/result/ExternalNetworkResponse.java
@@ -1,0 +1,19 @@
+package io.uranus.utility.bundle.core.utility.connection.helper.connector.element.result;
+
+import lombok.*;
+import org.springframework.http.HttpStatusCode;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class ExternalNetworkResponse {
+
+    private HttpStatusCode status;
+    private String body;
+
+    public static ExternalNetworkResponse create(HttpStatusCode status, String body) {
+        return new ExternalNetworkResponse(status, body);
+    }
+}

--- a/src/test/java/io/uranus/utility/bundle/core/utility/NetworkSubEngineTest.java
+++ b/src/test/java/io/uranus/utility/bundle/core/utility/NetworkSubEngineTest.java
@@ -1,0 +1,26 @@
+package io.uranus.utility.bundle.core.utility;
+
+import io.uranus.utility.bundle.core.global.support.test.dummy.DummyObject;
+import io.uranus.utility.bundle.core.utility.connection.helper.connector.element.result.ExternalNetworkResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class NetworkSubEngineTest {
+
+    @Test
+    void isChained() {
+        final String someUrl = "https://example.com";
+        DummyObject bodyObject = DummyObject.createObject();
+
+        ExternalNetworkResponse response = UranusUtilityEngine.network().open()
+                .post()
+                .url(someUrl)
+                .headers(headers -> {
+                    headers.add("Content-Type", "application/json");
+                    headers.add("Accept", "application/json");
+                })
+                .body(UranusUtilityEngine.json().writeToJson(bodyObject))
+                .execute();
+    }
+}


### PR DESCRIPTION
- A new sub-engine, NetworkHelper, has been created.
- NetworkConnector supports chaining and lazy loading operations for each phase of an HTTP request. The actual HTTP request will not be executed unless the final connection method is explicitly called.
- NetworkConnector is designed as a disposable, one-time-use instance. If the final connection method is not called, any changes to the internal state will not be applied.